### PR TITLE
Fix SubsamplingScaleImageView don't use orientation from EXIF

### DIFF
--- a/library/src/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
+++ b/library/src/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
@@ -123,7 +123,7 @@ public class SubsamplingScaleImageView extends View {
     private boolean debug;
 
     // Image orientation setting
-    private int orientation = ORIENTATION_0;
+    private int orientation = ORIENTATION_USE_EXIF;
 
     // Max scale allowed (prevent infinite zoom)
     private float maxScale = 2F;


### PR DESCRIPTION
Fix SubsamplingScaleImageView don't use orientation from EXIF