### PR TITLE
Use factory pattern for ImageDecoder and ImageRegionDecoder

### DIFF
--- a/library/src/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
+++ b/library/src/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
@@ -46,11 +46,12 @@ import android.view.MotionEvent;
 import android.view.View;
 
 import com.davemorrissey.labs.subscaleview.R.styleable;
+import com.davemorrissey.labs.subscaleview.decoder.CompatDecoderFactory;
 import com.davemorrissey.labs.subscaleview.decoder.DecoderFactory;
 import com.davemorrissey.labs.subscaleview.decoder.ImageDecoder;
 import com.davemorrissey.labs.subscaleview.decoder.ImageRegionDecoder;
-import com.davemorrissey.labs.subscaleview.decoder.SkiaImageDecoderFactory;
-import com.davemorrissey.labs.subscaleview.decoder.SkiaImageRegionDecoderFactory;
+import com.davemorrissey.labs.subscaleview.decoder.SkiaImageDecoder;
+import com.davemorrissey.labs.subscaleview.decoder.SkiaImageRegionDecoder;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -198,8 +199,8 @@ public class SubsamplingScaleImageView extends View {
     // Tile and image decoding
     private ImageRegionDecoder decoder;
     private final Object decoderLock = new Object();
-    private DecoderFactory<? extends ImageDecoder> bitmapDecoderFactory = new SkiaImageDecoderFactory();
-    private DecoderFactory<? extends ImageRegionDecoder> regionDecoderFactory = new SkiaImageRegionDecoderFactory();
+    private DecoderFactory<? extends ImageDecoder> bitmapDecoderFactory = new CompatDecoderFactory<ImageDecoder>(SkiaImageDecoder.class);
+    private DecoderFactory<? extends ImageRegionDecoder> regionDecoderFactory = new CompatDecoderFactory<ImageRegionDecoder>(SkiaImageRegionDecoder.class);
 
     // Debug values
     private PointF vCenterStart;
@@ -1973,16 +1974,43 @@ public class SubsamplingScaleImageView extends View {
     }
 
     /**
+     *
+     * Swap the default region decoder implementation for one of your own. You must do this before setting the image file or
+     * asset, and you cannot use a custom decoder when using layout XML to set an asset name. Your class must have a
+     * public default constructor.
+     * @param regionDecoderClass The {@link ImageRegionDecoder} implementation to use.
+     */
+    public final void setRegionDecoderClass(Class<? extends ImageRegionDecoder> regionDecoderClass) {
+        if (regionDecoderClass == null) {
+            throw new IllegalArgumentException("Decoder class cannot be set to null");
+        }
+        this.regionDecoderFactory = new CompatDecoderFactory<ImageRegionDecoder>(regionDecoderClass);
+    }
+
+    /**
      * Swap the default region decoder implementation for one of your own. You must do this before setting the image file or
      * asset, and you cannot use a custom decoder when using layout XML to set an asset name.
      * @param regionDecoderFactory The {@link DecoderFactory} implementation that produces {@link ImageRegionDecoder}
      *                             instances.
      */
-    public final void setRegionDecoderClass(DecoderFactory<? extends ImageRegionDecoder> regionDecoderFactory) {
+    public final void setRegionDecoderFactory(DecoderFactory<? extends ImageRegionDecoder> regionDecoderFactory) {
         if (regionDecoderFactory == null) {
             throw new IllegalArgumentException("Decoder factory cannot be set to null");
         }
         this.regionDecoderFactory = regionDecoderFactory;
+    }
+
+    /**
+     * Swap the default bitmap decoder implementation for one of your own. You must do this before setting the image file or
+     * asset, and you cannot use a custom decoder when using layout XML to set an asset name. Your class must have a
+     * public default constructor.
+     * @param bitmapDecoderClass The {@link ImageDecoder} implementation to use.
+     */
+    public final void setBitmapDecoderClass(Class<? extends ImageDecoder> bitmapDecoderClass) {
+        if (bitmapDecoderClass == null) {
+            throw new IllegalArgumentException("Decoder class cannot be set to null");
+        }
+        this.bitmapDecoderFactory = new CompatDecoderFactory<ImageDecoder>(bitmapDecoderClass);
     }
 
     /**

--- a/library/src/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
+++ b/library/src/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
@@ -19,8 +19,16 @@ package com.davemorrissey.labs.subscaleview;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.graphics.*;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Matrix;
+import android.graphics.Paint;
 import android.graphics.Paint.Style;
+import android.graphics.Point;
+import android.graphics.PointF;
+import android.graphics.Rect;
+import android.graphics.RectF;
 import android.media.ExifInterface;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -36,14 +44,20 @@ import android.util.TypedValue;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.View;
+
 import com.davemorrissey.labs.subscaleview.R.styleable;
+import com.davemorrissey.labs.subscaleview.decoder.DecoderFactory;
 import com.davemorrissey.labs.subscaleview.decoder.ImageDecoder;
 import com.davemorrissey.labs.subscaleview.decoder.ImageRegionDecoder;
-import com.davemorrissey.labs.subscaleview.decoder.SkiaImageDecoder;
-import com.davemorrissey.labs.subscaleview.decoder.SkiaImageRegionDecoder;
+import com.davemorrissey.labs.subscaleview.decoder.SkiaImageDecoderFactory;
+import com.davemorrissey.labs.subscaleview.decoder.SkiaImageRegionDecoderFactory;
 
 import java.lang.ref.WeakReference;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Displays an image subsampled as necessary to avoid loading too much image data into memory. After a pinch to zoom in,
@@ -184,8 +198,8 @@ public class SubsamplingScaleImageView extends View {
     // Tile and image decoding
     private ImageRegionDecoder decoder;
     private final Object decoderLock = new Object();
-    private Class<? extends ImageRegionDecoder> regionDecoderClass = SkiaImageRegionDecoder.class;
-    private Class<? extends ImageDecoder> bitmapDecoderClass = SkiaImageDecoder.class;
+    private DecoderFactory<? extends ImageDecoder> bitmapDecoderFactory = new SkiaImageDecoderFactory();
+    private DecoderFactory<? extends ImageRegionDecoder> regionDecoderFactory = new SkiaImageRegionDecoderFactory();
 
     // Debug values
     private PointF vCenterStart;
@@ -366,7 +380,7 @@ public class SubsamplingScaleImageView extends View {
                 if (uri == null && previewSource.getResource() != null) {
                     uri = Uri.parse(ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + getContext().getPackageName() + "/" + previewSource.getResource());
                 }
-                BitmapLoadTask task = new BitmapLoadTask(this, getContext(), bitmapDecoderClass, uri, true);
+                BitmapLoadTask task = new BitmapLoadTask(this, getContext(), bitmapDecoderFactory, uri, true);
                 task.execute();
             }
         }
@@ -383,11 +397,11 @@ public class SubsamplingScaleImageView extends View {
             }
             if (imageSource.getTile() || this.sRegion != null) {
                 // Load the bitmap using tile decoding.
-                TilesInitTask task = new TilesInitTask(this, getContext(), regionDecoderClass, uri);
+                TilesInitTask task = new TilesInitTask(this, getContext(), regionDecoderFactory, uri);
                 task.execute();
             } else {
                 // Load the bitmap as a single image.
-                BitmapLoadTask task = new BitmapLoadTask(this, getContext(), bitmapDecoderClass, uri, false);
+                BitmapLoadTask task = new BitmapLoadTask(this, getContext(), bitmapDecoderFactory, uri, false);
                 task.execute();
             }
         }
@@ -1327,15 +1341,15 @@ public class SubsamplingScaleImageView extends View {
     private static class TilesInitTask extends AsyncTask<Void, Void, int[]> {
         private final WeakReference<SubsamplingScaleImageView> viewRef;
         private final WeakReference<Context> contextRef;
-        private final WeakReference<Class<? extends ImageRegionDecoder>> decoderClassRef;
+        private final WeakReference<DecoderFactory<? extends ImageRegionDecoder>> decoderFactoryRef;
         private final Uri source;
         private ImageRegionDecoder decoder;
         private Exception exception;
 
-        public TilesInitTask(SubsamplingScaleImageView view, Context context, Class<? extends ImageRegionDecoder> decoderClass, Uri source) {
+        public TilesInitTask(SubsamplingScaleImageView view, Context context, DecoderFactory<? extends ImageRegionDecoder> decoderFactory, Uri source) {
             this.viewRef = new WeakReference<SubsamplingScaleImageView>(view);
             this.contextRef = new WeakReference<Context>(context);
-            this.decoderClassRef = new WeakReference<Class<? extends ImageRegionDecoder>>(decoderClass);
+            this.decoderFactoryRef = new WeakReference<DecoderFactory<? extends ImageRegionDecoder>>(decoderFactory);
             this.source = source;
         }
 
@@ -1344,10 +1358,10 @@ public class SubsamplingScaleImageView extends View {
             try {
                 String sourceUri = source.toString();
                 Context context = contextRef.get();
-                Class<? extends ImageRegionDecoder> decoderClass = decoderClassRef.get();
+                DecoderFactory<? extends ImageRegionDecoder> decoderFactory = decoderFactoryRef.get();
                 SubsamplingScaleImageView view = viewRef.get();
-                if (context != null && decoderClass != null && view != null) {
-                    decoder = decoderClass.newInstance();
+                if (context != null && decoderFactory != null && view != null) {
+                    decoder = decoderFactory.make();
                     Point dimensions = decoder.init(context, source);
                     int sWidth = dimensions.x;
                     int sHeight = dimensions.y;
@@ -1478,16 +1492,16 @@ public class SubsamplingScaleImageView extends View {
     private static class BitmapLoadTask extends AsyncTask<Void, Void, Integer> {
         private final WeakReference<SubsamplingScaleImageView> viewRef;
         private final WeakReference<Context> contextRef;
-        private final WeakReference<Class<? extends ImageDecoder>> decoderClassRef;
+        private final WeakReference<DecoderFactory<? extends ImageDecoder>> decoderFactoryRef;
         private final Uri source;
         private final boolean preview;
         private Bitmap bitmap;
         private Exception exception;
 
-        public BitmapLoadTask(SubsamplingScaleImageView view, Context context, Class<? extends ImageDecoder> decoderClass, Uri source, boolean preview) {
+        public BitmapLoadTask(SubsamplingScaleImageView view, Context context, DecoderFactory<? extends ImageDecoder> decoderFactory, Uri source, boolean preview) {
             this.viewRef = new WeakReference<SubsamplingScaleImageView>(view);
             this.contextRef = new WeakReference<Context>(context);
-            this.decoderClassRef = new WeakReference<Class<? extends ImageDecoder>>(decoderClass);
+            this.decoderFactoryRef = new WeakReference<DecoderFactory<? extends ImageDecoder>>(decoderFactory);
             this.source = source;
             this.preview = preview;
         }
@@ -1497,10 +1511,10 @@ public class SubsamplingScaleImageView extends View {
             try {
                 String sourceUri = source.toString();
                 Context context = contextRef.get();
-                Class<? extends ImageDecoder> decoderClass = decoderClassRef.get();
+                DecoderFactory<? extends ImageDecoder> decoderFactory = decoderFactoryRef.get();
                 SubsamplingScaleImageView subsamplingScaleImageView = viewRef.get();
-                if (context != null && decoderClass != null && subsamplingScaleImageView != null) {
-                    bitmap = decoderClass.newInstance().decode(context, source);
+                if (context != null && decoderFactory != null && subsamplingScaleImageView != null) {
+                    bitmap = decoderFactory.make().decode(context, source);
                     return subsamplingScaleImageView.getExifOrientation(sourceUri);
                 }
             } catch (Exception e) {
@@ -1960,28 +1974,27 @@ public class SubsamplingScaleImageView extends View {
 
     /**
      * Swap the default region decoder implementation for one of your own. You must do this before setting the image file or
-     * asset, and you cannot use a custom decoder when using layout XML to set an asset name. Your class must have a
-     * public default constructor.
-     * @param regionDecoderClass The {@link ImageRegionDecoder} implementation to use.
+     * asset, and you cannot use a custom decoder when using layout XML to set an asset name.
+     * @param regionDecoderFactory The {@link DecoderFactory} implementation that produces {@link ImageRegionDecoder}
+     *                             instances.
      */
-    public final void setRegionDecoderClass(Class<? extends ImageRegionDecoder> regionDecoderClass) {
-        if (regionDecoderClass == null) {
-            throw new IllegalArgumentException("Decoder class cannot be set to null");
+    public final void setRegionDecoderClass(DecoderFactory<? extends ImageRegionDecoder> regionDecoderFactory) {
+        if (regionDecoderFactory == null) {
+            throw new IllegalArgumentException("Decoder factory cannot be set to null");
         }
-        this.regionDecoderClass = regionDecoderClass;
+        this.regionDecoderFactory = regionDecoderFactory;
     }
 
     /**
      * Swap the default bitmap decoder implementation for one of your own. You must do this before setting the image file or
-     * asset, and you cannot use a custom decoder when using layout XML to set an asset name. Your class must have a
-     * public default constructor.
-     * @param bitmapDecoderClass The {@link ImageDecoder} implementation to use.
+     * asset, and you cannot use a custom decoder when using layout XML to set an asset name.
+     * @param bitmapDecoderFactory The {@link DecoderFactory} implementation that produces {@link ImageDecoder} instances.
      */
-    public final void setBitmapDecoderClass(Class<? extends ImageDecoder> bitmapDecoderClass) {
-        if (bitmapDecoderClass == null) {
-            throw new IllegalArgumentException("Decoder class cannot be set to null");
+    public final void setBitmapDecoderFactory(DecoderFactory<? extends ImageDecoder> bitmapDecoderFactory) {
+        if (bitmapDecoderFactory == null) {
+            throw new IllegalArgumentException("Decoder factory cannot be set to null");
         }
-        this.bitmapDecoderClass = bitmapDecoderClass;
+        this.bitmapDecoderFactory = bitmapDecoderFactory;
     }
 
     /**

--- a/library/src/com/davemorrissey/labs/subscaleview/decoder/CompatDecoderFactory.java
+++ b/library/src/com/davemorrissey/labs/subscaleview/decoder/CompatDecoderFactory.java
@@ -1,0 +1,20 @@
+package com.davemorrissey.labs.subscaleview.decoder;
+
+import android.support.annotation.NonNull;
+
+/**
+ * Compatibility factory to instantiate decoders with empty public constructors.
+ * @param <T> The base type of the decoder this factory will produce.
+ */
+public class CompatDecoderFactory <T> implements DecoderFactory<T> {
+  private Class<? extends T> clazz;
+
+  public CompatDecoderFactory(@NonNull Class<? extends T> clazz) {
+    this.clazz = clazz;
+  }
+
+  @Override
+  public T make() throws IllegalAccessException, InstantiationException {
+    return clazz.newInstance();
+  }
+}

--- a/library/src/com/davemorrissey/labs/subscaleview/decoder/DecoderFactory.java
+++ b/library/src/com/davemorrissey/labs/subscaleview/decoder/DecoderFactory.java
@@ -1,0 +1,13 @@
+package com.davemorrissey.labs.subscaleview.decoder;
+
+/**
+ * Interface for decoder (and region decoder) factories.
+ * @param <T> the class of decoder that will be produced.
+ */
+public interface DecoderFactory<T> {
+  /**
+   * Produce a new instance of a decoder with type {@link T}.
+   * @return a new instance of your decoder.
+   */
+  T make() throws IllegalAccessException, InstantiationException;
+}


### PR DESCRIPTION
Instead of requiring implementers of `ImageDecoder` and `ImageRegionDecoder` have an empty constructor, a factory pattern would allow for configurable decoders with constructor parameters (something that I need in my use case).

Great idea for a library by the way! Just what I was looking for.