### PR TITLE
Adding "isCached" boolean to allow external caching mechanisms to handle the bitmap lifecycle

### DIFF
--- a/library/src/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
+++ b/library/src/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
@@ -128,6 +128,9 @@ public class SubsamplingScaleImageView extends View {
     // Whether the bitmap is a preview image
     private boolean preview;
 
+    // Specifies if a cache handler is also referencing the bitmap. Do not recycle if so.
+    private boolean isCached = false;
+
     // Sample size used to display the whole image when fully zoomed out
     private int fullImageSampleSize;
 
@@ -441,7 +444,7 @@ public class SubsamplingScaleImageView extends View {
                     decoder = null;
                 }
             }
-            if (bitmap != null) {
+            if (bitmap != null && !isCached) {
                 bitmap.recycle();
             }
             sWidth = 0;
@@ -1405,7 +1408,7 @@ public class SubsamplingScaleImageView extends View {
         if (this.sWidth > 0 && this.sHeight > 0 && (this.sWidth != sWidth || this.sHeight != sHeight)) {
             reset(false);
             if (bitmap != null) {
-                bitmap.recycle();
+                if (!isCached) bitmap.recycle();
                 bitmap = null;
                 preview = false;
             }
@@ -1484,7 +1487,7 @@ public class SubsamplingScaleImageView extends View {
         checkReady();
         checkImageLoaded();
         if (isBaseLayerReady() && bitmap != null) {
-            bitmap.recycle();
+            if (!isCached) bitmap.recycle();
             bitmap = null;
             preview = false;
         }
@@ -1578,7 +1581,7 @@ public class SubsamplingScaleImageView extends View {
         if (this.sWidth > 0 && this.sHeight > 0 && (this.sWidth != bitmap.getWidth() || this.sHeight != bitmap.getHeight())) {
             reset(false);
         }
-        if (this.bitmap != null) {
+        if (this.bitmap != null && !isCached) {
             this.bitmap.recycle();
         }
         this.preview = false;
@@ -2347,6 +2350,14 @@ public class SubsamplingScaleImageView extends View {
             throw new IllegalArgumentException("Invalid zoom style: " + doubleTapZoomStyle);
         }
         this.doubleTapZoomStyle = doubleTapZoomStyle;
+    }
+
+    /**
+     * Set whether the view will be using cached bitmaps. No recyling should be performed
+     * as this will conflict with image loaders like Picasso or Volley.
+     */
+    protected final void setCacheEnabled(boolean isCached) {
+        this.isCached = isCached;
     }
 
     /**


### PR DESCRIPTION
When a 3rd party image loader like Picasso is used, the bitmaps are cached and memory managed independently. In the event where subsampling views are recycled in a recycler view or recycling pager, the bitmaps are recycled if the existing property bitmap != null.

Requesting to add a boolean flag to determine if an external image cache loader is used. If so, the bitmaps should not be recycled. Alternatively, would be to copy a new bitmap that can then be loaded into the Subsamplingview, which doesn't seem memory efficient for large images.

```
if (bitmap != null) {
    bitmap.recycle();
}
```

to 

```
if (bitmap != null && !isCached) {
    bitmap.recycle();
}
```
