### PR TITLE
fixing double touch on two different images

### DIFF
--- a/library/src/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
+++ b/library/src/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
@@ -740,7 +740,7 @@ public class SubsamplingScaleImageView extends View {
                                 // Haven't panned the image, and we're at the left or right edge. Switch to page swipe.
                                 maxTouchCount = 0;
                                 handler.removeMessages(MESSAGE_LONG_CLICK);
-                                getParent().requestDisallowInterceptTouchEvent(false);
+                                //getParent().requestDisallowInterceptTouchEvent(false);
                             }
 
                             if (!panEnabled) {


### PR DESCRIPTION
I was experienced a bug that was happening when I was trying to move two not-zoomed images, displayed side by side.

The full problem is described here: http://stackoverflow.com/questions/32653644/clicking-on-two-subsampling-scale-images-at-the-same-time-will-crash-android/

Actually I don't know if it will open other bugs or not. This change might need a review from the author.