### PR TITLE
Added a boolean value which allows the view to reset the scale and center automatically after its size was changed.

### DIFF
--- a/library/src/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
+++ b/library/src/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
@@ -266,6 +266,7 @@ public class SubsamplingScaleImageView extends View {
     //The logical density of the display
     private float density;
 
+    private boolean resetScaleAndCenterAfterSizeChanged = false;
 
     public SubsamplingScaleImageView(Context context, AttributeSet attr) {
         super(context, attr);
@@ -563,6 +564,8 @@ public class SubsamplingScaleImageView extends View {
             this.pendingScale = scale;
             this.sPendingCenter = sCenter;
         }
+
+        if (resetScaleAndCenterAfterSizeChanged) resetScaleAndCenter();
     }
 
     /**
@@ -2242,6 +2245,17 @@ public class SubsamplingScaleImageView extends View {
         DisplayMetrics metrics = getResources().getDisplayMetrics();
         float averageDpi = (metrics.xdpi + metrics.ydpi)/2;
         setMinScale(averageDpi / dpi);
+    }
+
+    /**
+     * Sometimes it is inconvenient to reset the scale and center if the view's size changed.
+     * Furthermore, the incorrect timing of calling the method resetScaleAndCenter() will make
+     * no effect in specific situations.
+     *
+     * @param reset Whether to reset scale and center after the view's size changed.
+     */
+    public void setResetScaleAndCenterAfterSizeChanged(boolean reset) {
+        this.resetScaleAndCenterAfterSizeChanged = reset;
     }
 
     /**


### PR DESCRIPTION
Sometimes, it is inconvenient to reset the scale and center if the view's size was changed in some situations such as an image viewer, thus a method was added in order to enable this approach much simpler to use. 
