### PR TITLE
Added null-check per method in onStateChangedListener

### DIFF
--- a/library/src/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
+++ b/library/src/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
@@ -2660,13 +2660,11 @@ public class SubsamplingScaleImageView extends View {
     }
 
     private void sendStateChanged(float oldScale, PointF oldVTranslate, int origin) {
-        if (onStateChangedListener != null) {
-            if (scale != oldScale) {
-                onStateChangedListener.onScaleChanged(scale, origin);
-            }
-            if (!vTranslate.equals(oldVTranslate)) {
-                onStateChangedListener.onCenterChanged(getCenter(), origin);
-            }
+        if (onStateChangedListener != null && scale != oldScale) {
+            onStateChangedListener.onScaleChanged(scale, origin);
+        }
+        if (onStateChangedListener != null && !vTranslate.equals(oldVTranslate)) {
+            onStateChangedListener.onCenterChanged(getCenter(), origin);
         }
     }
 


### PR DESCRIPTION
I want to be able to remove the OnStateChangedListener in onScaleChanged. This caused a NPE in `sendStateChanged()` when `onCenterChanged()` was called.