### PR TITLE
Support for other bitmap formats (not just default RGB565)

### DIFF
--- a/library/src/com/davemorrissey/labs/subscaleview/decoder/CompatDecoderFactory.java
+++ b/library/src/com/davemorrissey/labs/subscaleview/decoder/CompatDecoderFactory.java
@@ -1,20 +1,36 @@
 package com.davemorrissey.labs.subscaleview.decoder;
 
+import android.graphics.Bitmap;
 import android.support.annotation.NonNull;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 
 /**
  * Compatibility factory to instantiate decoders with empty public constructors.
  * @param <T> The base type of the decoder this factory will produce.
  */
-public class CompatDecoderFactory <T> implements DecoderFactory<T> {
+public class CompatDecoderFactory<T> implements DecoderFactory<T> {
   private Class<? extends T> clazz;
+  private Bitmap.Config bitmapConfig;
 
   public CompatDecoderFactory(@NonNull Class<? extends T> clazz) {
+    this(clazz, null);
+  }
+
+  public CompatDecoderFactory(@NonNull Class<? extends T> clazz, Bitmap.Config bitmapConfig) {
     this.clazz = clazz;
+    this.bitmapConfig = bitmapConfig;
   }
 
   @Override
-  public T make() throws IllegalAccessException, InstantiationException {
-    return clazz.newInstance();
+  public T make() throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+    if (bitmapConfig == null) {
+      return clazz.newInstance();
+    }
+    else {
+      Constructor<? extends T> ctor = clazz.getConstructor(Bitmap.Config.class);
+      return ctor.newInstance(bitmapConfig);
+    }
   }
 }

--- a/library/src/com/davemorrissey/labs/subscaleview/decoder/DecoderFactory.java
+++ b/library/src/com/davemorrissey/labs/subscaleview/decoder/DecoderFactory.java
@@ -1,5 +1,7 @@
 package com.davemorrissey.labs.subscaleview.decoder;
 
+import java.lang.reflect.InvocationTargetException;
+
 /**
  * Interface for decoder (and region decoder) factories.
  * @param <T> the class of decoder that will be produced.
@@ -9,5 +11,5 @@ public interface DecoderFactory<T> {
    * Produce a new instance of a decoder with type {@link T}.
    * @return a new instance of your decoder.
    */
-  T make() throws IllegalAccessException, InstantiationException;
+  T make() throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException;
 }

--- a/library/src/com/davemorrissey/labs/subscaleview/decoder/SkiaImageDecoder.java
+++ b/library/src/com/davemorrissey/labs/subscaleview/decoder/SkiaImageDecoder.java
@@ -24,12 +24,25 @@ public class SkiaImageDecoder implements ImageDecoder {
     private static final String ASSET_PREFIX = FILE_PREFIX + "/android_asset/";
     private static final String RESOURCE_PREFIX = ContentResolver.SCHEME_ANDROID_RESOURCE + "://";
 
+    private final Bitmap.Config bitmapConfig;
+
+    public SkiaImageDecoder() {
+        this(null);
+    }
+
+    public SkiaImageDecoder(Bitmap.Config bitmapConfig) {
+        if (bitmapConfig == null)
+            this.bitmapConfig = Bitmap.Config.RGB_565;
+        else
+            this.bitmapConfig = bitmapConfig;
+    }
+
     @Override
     public Bitmap decode(Context context, Uri uri) throws Exception {
         String uriString = uri.toString();
         BitmapFactory.Options options = new BitmapFactory.Options();
         Bitmap bitmap;
-        options.inPreferredConfig = Bitmap.Config.RGB_565;
+        options.inPreferredConfig = bitmapConfig;
         if (uriString.startsWith(RESOURCE_PREFIX)) {
             Resources res;
             String packageName = uri.getAuthority();

--- a/library/src/com/davemorrissey/labs/subscaleview/decoder/SkiaImageRegionDecoder.java
+++ b/library/src/com/davemorrissey/labs/subscaleview/decoder/SkiaImageRegionDecoder.java
@@ -28,6 +28,19 @@ public class SkiaImageRegionDecoder implements ImageRegionDecoder {
     private static final String ASSET_PREFIX = FILE_PREFIX + "/android_asset/";
     private static final String RESOURCE_PREFIX = ContentResolver.SCHEME_ANDROID_RESOURCE + "://";
 
+    private final Bitmap.Config bitmapConfig;
+
+    public SkiaImageRegionDecoder() {
+        this(null);
+    }
+
+    public SkiaImageRegionDecoder(Bitmap.Config bitmapConfig) {
+        if (bitmapConfig == null)
+            this.bitmapConfig = Bitmap.Config.RGB_565;
+        else
+            this.bitmapConfig = bitmapConfig;
+    }
+
     @Override
     public Point init(Context context, Uri uri) throws Exception {
         String uriString = uri.toString();
@@ -80,7 +93,7 @@ public class SkiaImageRegionDecoder implements ImageRegionDecoder {
         synchronized (decoderLock) {
             BitmapFactory.Options options = new BitmapFactory.Options();
             options.inSampleSize = sampleSize;
-            options.inPreferredConfig = Config.RGB_565;
+            options.inPreferredConfig = bitmapConfig;
             Bitmap bitmap = decoder.decodeRegion(sRect, options);
             if (bitmap == null) {
                 throw new RuntimeException("Skia image decoder returned null bitmap - image format may not be supported");


### PR DESCRIPTION
Decoder's preferred bitmap format can be altered.

1) create factory
DecoderFactory<? extends ImageDecoder> factory = new CompatDecoderFactory<>(SkiaImageDecoder.class, Bitmap.Config.ARGB_8888);
Second argument is optional, therefore the default behavior is not changed.

2) configure view with created factory
mView.setBitmapDecoderFactory(factory);

Why this feature is needed?
I have an image with a background color (for example a plan of a building) and i want to set background of my view the same color thus making borders invisible.
But if the image is displayed as RGB565 colors will be a bit different making this border visible.

