### PR TITLE
Support for adding a custom drawable to PinView

### DIFF
--- a/sample/src/main/java/com/davemorrissey/labs/subscaleview/test/extension/views/PinView.java
+++ b/sample/src/main/java/com/davemorrissey/labs/subscaleview/test/extension/views/PinView.java
@@ -13,6 +13,7 @@ public class PinView extends SubsamplingScaleImageView {
     private final PointF vPin = new PointF();
     private PointF sPin;
     private Bitmap pin;
+    private int imgRes = drawable.pushpin_blue;
 
     public PinView(Context context) {
         this(context, null);
@@ -28,10 +29,15 @@ public class PinView extends SubsamplingScaleImageView {
         initialise();
         invalidate();
     }
+    
+    public void setImgRes(int imgRes)
+    {
+        this.imgRes = imgRes;
+    }
 
     private void initialise() {
         float density = getResources().getDisplayMetrics().densityDpi;
-        pin = BitmapFactory.decodeResource(this.getResources(), drawable.pushpin_blue);
+        pin = BitmapFactory.decodeResource(this.getResources(), imgRes);
         float w = (density/420f) * pin.getWidth();
         float h = (density/420f) * pin.getHeight();
         pin = Bitmap.createScaledBitmap(pin, (int)w, (int)h, true);


### PR DESCRIPTION
This PR adds support for setting a custom drawable for a PinView by calling for example:
`pinView.setImage(R.drawable.banana);`