### PR TITLE
Added @Nullable and @NonNull annotations for Kotlin use

### DIFF
--- a/library/src/main/java/com/davemorrissey/labs/subscaleview/ImageSource.java
+++ b/library/src/main/java/com/davemorrissey/labs/subscaleview/ImageSource.java
@@ -3,6 +3,7 @@ package com.davemorrissey.labs.subscaleview;
 import android.graphics.Bitmap;
 import android.graphics.Rect;
 import android.net.Uri;
+import android.support.annotation.NonNull;
 
 import java.io.File;
 import java.io.UnsupportedEncodingException;
@@ -40,7 +41,7 @@ public final class ImageSource {
         this.cached = cached;
     }
 
-    private ImageSource(Uri uri) {
+    private ImageSource(@NonNull Uri uri) {
         // #114 If file doesn't exist, attempt to url decode the URI and try again
         String uriString = uri.toString();
         if (uriString.startsWith(FILE_SCHEME)) {
@@ -71,6 +72,7 @@ public final class ImageSource {
      * @param resId resource ID.
      * @return an {@link ImageSource} instance.
      */
+    @NonNull
     public static ImageSource resource(int resId) {
         return new ImageSource(resId);
     }
@@ -80,7 +82,9 @@ public final class ImageSource {
      * @param assetName asset name.
      * @return an {@link ImageSource} instance.
      */
-    public static ImageSource asset(String assetName) {
+    @NonNull
+    public static ImageSource asset(@NonNull String assetName) {
+        //noinspection ConstantConditions
         if (assetName == null) {
             throw new NullPointerException("Asset name must not be null");
         }
@@ -93,7 +97,9 @@ public final class ImageSource {
      * @param uri image URI.
      * @return an {@link ImageSource} instance.
      */
-    public static ImageSource uri(String uri) {
+    @NonNull
+    public static ImageSource uri(@NonNull String uri) {
+        //noinspection ConstantConditions
         if (uri == null) {
             throw new NullPointerException("Uri must not be null");
         }
@@ -111,7 +117,9 @@ public final class ImageSource {
      * @param uri image URI.
      * @return an {@link ImageSource} instance.
      */
-    public static ImageSource uri(Uri uri) {
+    @NonNull
+    public static ImageSource uri(@NonNull Uri uri) {
+        //noinspection ConstantConditions
         if (uri == null) {
             throw new NullPointerException("Uri must not be null");
         }
@@ -123,7 +131,9 @@ public final class ImageSource {
      * @param bitmap bitmap to be displayed.
      * @return an {@link ImageSource} instance.
      */
-    public static ImageSource bitmap(Bitmap bitmap) {
+    @NonNull
+    public static ImageSource bitmap(@NonNull Bitmap bitmap) {
+        //noinspection ConstantConditions
         if (bitmap == null) {
             throw new NullPointerException("Bitmap must not be null");
         }
@@ -137,7 +147,9 @@ public final class ImageSource {
      * @param bitmap bitmap to be displayed.
      * @return an {@link ImageSource} instance.
      */
-    public static ImageSource cachedBitmap(Bitmap bitmap) {
+    @NonNull
+    public static ImageSource cachedBitmap(@NonNull Bitmap bitmap) {
+        //noinspection ConstantConditions
         if (bitmap == null) {
             throw new NullPointerException("Bitmap must not be null");
         }
@@ -149,6 +161,7 @@ public final class ImageSource {
      * and tiling cannot be disabled when displaying a region of the source image.
      * @return this instance for chaining.
      */
+    @NonNull
     public ImageSource tilingEnabled() {
         return tiling(true);
     }
@@ -158,6 +171,7 @@ public final class ImageSource {
      * and tiling cannot be disabled when displaying a region of the source image.
      * @return this instance for chaining.
      */
+    @NonNull
     public ImageSource tilingDisabled() {
         return tiling(false);
     }
@@ -168,6 +182,7 @@ public final class ImageSource {
      * @param tile whether tiling should be enabled.
      * @return this instance for chaining.
      */
+    @NonNull
     public ImageSource tiling(boolean tile) {
         this.tile = tile;
         return this;
@@ -179,6 +194,7 @@ public final class ImageSource {
      * @param sRegion the region of the source image to be displayed.
      * @return this instance for chaining.
      */
+    @NonNull
     public ImageSource region(Rect sRegion) {
         this.sRegion = sRegion;
         setInvariants();
@@ -193,6 +209,7 @@ public final class ImageSource {
      * @param sHeight height of the source image.
      * @return this instance for chaining.
      */
+    @NonNull
     public ImageSource dimensions(int sWidth, int sHeight) {
         if (bitmap == null) {
             this.sWidth = sWidth;

--- a/library/src/main/java/com/davemorrissey/labs/subscaleview/ImageViewState.java
+++ b/library/src/main/java/com/davemorrissey/labs/subscaleview/ImageViewState.java
@@ -1,6 +1,7 @@
 package com.davemorrissey.labs.subscaleview;
 
 import android.graphics.PointF;
+import android.support.annotation.NonNull;
 
 import java.io.Serializable;
 
@@ -18,7 +19,7 @@ public class ImageViewState implements Serializable {
 
     private final int orientation;
 
-    public ImageViewState(float scale, PointF center, int orientation) {
+    public ImageViewState(float scale, @NonNull PointF center, int orientation) {
         this.scale = scale;
         this.centerX = center.x;
         this.centerY = center.y;
@@ -29,7 +30,7 @@ public class ImageViewState implements Serializable {
         return scale;
     }
 
-    public PointF getCenter() {
+    @NonNull public PointF getCenter() {
         return new PointF(centerX, centerY);
     }
 

--- a/library/src/main/java/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
+++ b/library/src/main/java/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
@@ -14,6 +14,7 @@ import android.graphics.Point;
 import android.graphics.PointF;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import android.support.annotation.Nullable;
 import android.support.media.ExifInterface;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -376,7 +377,7 @@ public class SubsamplingScaleImageView extends View {
      * Set the image source from a bitmap, resource, asset, file or other URI.
      * @param imageSource Image source.
      */
-    public final void setImage(ImageSource imageSource) {
+    public final void setImage(@NonNull ImageSource imageSource) {
         setImage(imageSource, null, null);
     }
 
@@ -387,7 +388,7 @@ public class SubsamplingScaleImageView extends View {
      * @param imageSource Image source.
      * @param state State to be restored. Nullable.
      */
-    public final void setImage(ImageSource imageSource, ImageViewState state) {
+    public final void setImage(@NonNull ImageSource imageSource, ImageViewState state) {
         setImage(imageSource, null, state);
     }
 
@@ -401,7 +402,7 @@ public class SubsamplingScaleImageView extends View {
      * @param imageSource Image source. Dimensions must be declared.
      * @param previewSource Optional source for a preview image to be displayed and allow interaction while the full size image loads.
      */
-    public final void setImage(ImageSource imageSource, ImageSource previewSource) {
+    public final void setImage(@NonNull ImageSource imageSource, ImageSource previewSource) {
         setImage(imageSource, previewSource, null);
     }
 
@@ -418,7 +419,8 @@ public class SubsamplingScaleImageView extends View {
      * @param previewSource Optional source for a preview image to be displayed and allow interaction while the full size image loads.
      * @param state State to be restored. Nullable.
      */
-    public final void setImage(ImageSource imageSource, ImageSource previewSource, ImageViewState state) {
+    public final void setImage(@NonNull ImageSource imageSource, ImageSource previewSource, ImageViewState state) {
+        //noinspection ConstantConditions
         if (imageSource == null) {
             throw new NullPointerException("imageSource must not be null");
         }
@@ -1114,15 +1116,19 @@ public class SubsamplingScaleImageView extends View {
             canvas.drawText("Scale: " + String.format(Locale.ENGLISH, "%.2f", scale) + " (" + String.format(Locale.ENGLISH, "%.2f", minScale()) + " - " + String.format(Locale.ENGLISH, "%.2f", maxScale) + ")", px(5), px(15), debugTextPaint);
             canvas.drawText("Translate: " + String.format(Locale.ENGLISH, "%.2f", vTranslate.x) + ":" + String.format(Locale.ENGLISH, "%.2f", vTranslate.y), px(5), px(30), debugTextPaint);
             PointF center = getCenter();
+            //noinspection ConstantConditions
             canvas.drawText("Source center: " + String.format(Locale.ENGLISH, "%.2f", center.x) + ":" + String.format(Locale.ENGLISH, "%.2f", center.y), px(5), px(45), debugTextPaint);
             if (anim != null) {
                 PointF vCenterStart = sourceToViewCoord(anim.sCenterStart);
                 PointF vCenterEndRequested = sourceToViewCoord(anim.sCenterEndRequested);
                 PointF vCenterEnd = sourceToViewCoord(anim.sCenterEnd);
+                //noinspection ConstantConditions
                 canvas.drawCircle(vCenterStart.x, vCenterStart.y, px(10), debugLinePaint);
                 debugLinePaint.setColor(Color.RED);
+                //noinspection ConstantConditions
                 canvas.drawCircle(vCenterEndRequested.x, vCenterEndRequested.y, px(20), debugLinePaint);
                 debugLinePaint.setColor(Color.BLUE);
+                //noinspection ConstantConditions
                 canvas.drawCircle(vCenterEnd.x, vCenterEnd.y, px(25), debugLinePaint);
                 debugLinePaint.setColor(Color.CYAN);
                 canvas.drawCircle(getWidth() / 2, getHeight() / 2, px(30), debugLinePaint);
@@ -1240,7 +1246,7 @@ public class SubsamplingScaleImageView extends View {
      * Called on first draw when the view has dimensions. Calculates the initial sample size and starts async loading of
      * the base layer image - the whole source subsampled as necessary.
      */
-    private synchronized void initialiseBaseLayer(Point maxTileDimensions) {
+    private synchronized void initialiseBaseLayer(@NonNull Point maxTileDimensions) {
         debug("initialiseBaseLayer maxTileDimensions=%dx%d", maxTileDimensions.x, maxTileDimensions.y);
 
         satTemp = new ScaleAndTranslate(0f, new PointF(0, 0));
@@ -1920,7 +1926,7 @@ public class SubsamplingScaleImageView extends View {
      * Set scale, center and orientation from saved state.
      */
     private void restoreState(ImageViewState state) {
-        if (state != null && state.getCenter() != null && VALID_ORIENTATIONS.contains(state.getOrientation())) {
+        if (state != null && VALID_ORIENTATIONS.contains(state.getOrientation())) {
             this.orientation = state.getOrientation();
             this.pendingScale = state.getScale();
             this.sPendingCenter = state.getCenter();
@@ -1952,6 +1958,7 @@ public class SubsamplingScaleImageView extends View {
     /**
      * Use canvas max bitmap width and height instead of the default 2048, to avoid redundant tiling.
      */
+    @NonNull
     private Point getMaxBitmapDimensions(Canvas canvas) {
         return new Point(Math.min(canvas.getMaximumBitmapWidth(), maxTileWidth), Math.min(canvas.getMaximumBitmapHeight(), maxTileHeight));
     }
@@ -2102,6 +2109,7 @@ public class SubsamplingScaleImageView extends View {
      * @param vxy view X/Y coordinate.
      * @return a coordinate representing the corresponding source coordinate.
      */
+    @Nullable
     public final PointF viewToSourceCoord(PointF vxy) {
         return viewToSourceCoord(vxy.x, vxy.y, new PointF());
     }
@@ -2112,6 +2120,7 @@ public class SubsamplingScaleImageView extends View {
      * @param vy view Y coordinate.
      * @return a coordinate representing the corresponding source coordinate.
      */
+    @Nullable
     public final PointF viewToSourceCoord(float vx, float vy) {
         return viewToSourceCoord(vx, vy, new PointF());
     }
@@ -2122,7 +2131,8 @@ public class SubsamplingScaleImageView extends View {
      * @param sTarget target object for result. The same instance is also returned.
      * @return source coordinates. This is the same instance passed to the sTarget param.
      */
-    public final PointF viewToSourceCoord(PointF vxy, PointF sTarget) {
+    @Nullable
+    public final PointF viewToSourceCoord(PointF vxy, @NonNull PointF sTarget) {
         return viewToSourceCoord(vxy.x, vxy.y, sTarget);
     }
 
@@ -2133,7 +2143,8 @@ public class SubsamplingScaleImageView extends View {
      * @param sTarget target object for result. The same instance is also returned.
      * @return source coordinates. This is the same instance passed to the sTarget param.
      */
-    public final PointF viewToSourceCoord(float vx, float vy, PointF sTarget) {
+    @Nullable
+    public final PointF viewToSourceCoord(float vx, float vy, @NonNull PointF sTarget) {
         if (vTranslate == null) {
             return null;
         }
@@ -2162,6 +2173,7 @@ public class SubsamplingScaleImageView extends View {
      * @param sxy source coordinates to convert.
      * @return view coordinates.
      */
+    @Nullable
     public final PointF sourceToViewCoord(PointF sxy) {
         return sourceToViewCoord(sxy.x, sxy.y, new PointF());
     }
@@ -2172,6 +2184,7 @@ public class SubsamplingScaleImageView extends View {
      * @param sy source Y coordinate.
      * @return view coordinates.
      */
+    @Nullable
     public final PointF sourceToViewCoord(float sx, float sy) {
         return sourceToViewCoord(sx, sy, new PointF());
     }
@@ -2183,7 +2196,8 @@ public class SubsamplingScaleImageView extends View {
      * @return view coordinates. This is the same instance passed to the vTarget param.
      */
     @SuppressWarnings("UnusedReturnValue")
-    public final PointF sourceToViewCoord(PointF sxy, PointF vTarget) {
+    @Nullable
+    public final PointF sourceToViewCoord(PointF sxy, @NonNull PointF vTarget) {
         return sourceToViewCoord(sxy.x, sxy.y, vTarget);
     }
 
@@ -2194,7 +2208,8 @@ public class SubsamplingScaleImageView extends View {
      * @param vTarget target object for result. The same instance is also returned.
      * @return view coordinates. This is the same instance passed to the vTarget param.
      */
-    public final PointF sourceToViewCoord(float sx, float sy, PointF vTarget) {
+    @Nullable
+    public final PointF sourceToViewCoord(float sx, float sy, @NonNull PointF vTarget) {
         if (vTranslate == null) {
             return null;
         }
@@ -2205,7 +2220,7 @@ public class SubsamplingScaleImageView extends View {
     /**
      * Convert source rect to screen rect, integer values.
      */
-    private void sourceToViewRect(Rect sRect, Rect vTarget) {
+    private void sourceToViewRect(@NonNull Rect sRect, @NonNull Rect vTarget) {
         vTarget.set(
             (int)sourceToViewX(sRect.left),
             (int)sourceToViewY(sRect.top),
@@ -2219,6 +2234,7 @@ public class SubsamplingScaleImageView extends View {
      * adjusted for asymmetric padding. Accepts the desired scale as an argument, so this is independent of current
      * translate and scale. The result is fitted to bounds, putting the image point as near to the screen center as permitted.
      */
+    @NonNull
     private PointF vTranslateForSCenter(float sCenterX, float sCenterY, float scale) {
         int vxCenter = getPaddingLeft() + (getWidth() - getPaddingRight() - getPaddingLeft())/2;
         int vyCenter = getPaddingTop() + (getHeight() - getPaddingBottom() - getPaddingTop())/2;
@@ -2235,7 +2251,8 @@ public class SubsamplingScaleImageView extends View {
      * Given a requested source center and scale, calculate what the actual center will have to be to keep the image in
      * pan limits, keeping the requested center as near to the middle of the screen as allowed.
      */
-    private PointF limitedSCenter(float sCenterX, float sCenterY, float scale, PointF sTarget) {
+    @NonNull
+    private PointF limitedSCenter(float sCenterX, float sCenterY, float scale, @NonNull PointF sTarget) {
         PointF vTranslate = vTranslateForSCenter(sCenterX, sCenterY, scale);
         int vxCenter = getPaddingLeft() + (getWidth() - getPaddingRight() - getPaddingLeft())/2;
         int vyCenter = getPaddingTop() + (getHeight() - getPaddingBottom() - getPaddingTop())/2;
@@ -2344,7 +2361,8 @@ public class SubsamplingScaleImageView extends View {
      * public default constructor.
      * @param regionDecoderClass The {@link ImageRegionDecoder} implementation to use.
      */
-    public final void setRegionDecoderClass(Class<? extends ImageRegionDecoder> regionDecoderClass) {
+    public final void setRegionDecoderClass(@NonNull Class<? extends ImageRegionDecoder> regionDecoderClass) {
+        //noinspection ConstantConditions
         if (regionDecoderClass == null) {
             throw new IllegalArgumentException("Decoder class cannot be set to null");
         }
@@ -2357,7 +2375,8 @@ public class SubsamplingScaleImageView extends View {
      * @param regionDecoderFactory The {@link DecoderFactory} implementation that produces {@link ImageRegionDecoder}
      *                             instances.
      */
-    public final void setRegionDecoderFactory(DecoderFactory<? extends ImageRegionDecoder> regionDecoderFactory) {
+    public final void setRegionDecoderFactory(@NonNull DecoderFactory<? extends ImageRegionDecoder> regionDecoderFactory) {
+        //noinspection ConstantConditions
         if (regionDecoderFactory == null) {
             throw new IllegalArgumentException("Decoder factory cannot be set to null");
         }
@@ -2370,7 +2389,8 @@ public class SubsamplingScaleImageView extends View {
      * public default constructor.
      * @param bitmapDecoderClass The {@link ImageDecoder} implementation to use.
      */
-    public final void setBitmapDecoderClass(Class<? extends ImageDecoder> bitmapDecoderClass) {
+    public final void setBitmapDecoderClass(@NonNull Class<? extends ImageDecoder> bitmapDecoderClass) {
+        //noinspection ConstantConditions
         if (bitmapDecoderClass == null) {
             throw new IllegalArgumentException("Decoder class cannot be set to null");
         }
@@ -2382,7 +2402,8 @@ public class SubsamplingScaleImageView extends View {
      * asset, and you cannot use a custom decoder when using layout XML to set an asset name.
      * @param bitmapDecoderFactory The {@link DecoderFactory} implementation that produces {@link ImageDecoder} instances.
      */
-    public final void setBitmapDecoderFactory(DecoderFactory<? extends ImageDecoder> bitmapDecoderFactory) {
+    public final void setBitmapDecoderFactory(@NonNull DecoderFactory<? extends ImageDecoder> bitmapDecoderFactory) {
+        //noinspection ConstantConditions
         if (bitmapDecoderFactory == null) {
             throw new IllegalArgumentException("Decoder factory cannot be set to null");
         }
@@ -2531,6 +2552,7 @@ public class SubsamplingScaleImageView extends View {
      * Returns the source point at the center of the view.
      * @return the source coordinates current at the center of the view.
      */
+    @Nullable
     public final PointF getCenter() {
         int mX = getWidth()/2;
         int mY = getHeight()/2;
@@ -2551,7 +2573,7 @@ public class SubsamplingScaleImageView extends View {
      * @param scale New scale to set.
      * @param sCenter New source image coordinate to center on the screen, subject to boundaries.
      */
-    public final void setScaleAndCenter(float scale, PointF sCenter) {
+    public final void setScaleAndCenter(float scale, @Nullable PointF sCenter) {
         this.anim = null;
         this.pendingScale = scale;
         this.sPendingCenter = sCenter;
@@ -2653,8 +2675,10 @@ public class SubsamplingScaleImageView extends View {
      * the view is not ready.
      * @return an {@link ImageViewState} instance representing the current position of the image. null if the view isn't ready.
      */
+    @Nullable
     public final ImageViewState getState() {
         if (vTranslate != null && sWidth > 0 && sHeight > 0) {
+            //noinspection ConstantConditions
             return new ImageViewState(getScale(), getCenter(), getOrientation());
         }
         return null;
@@ -2790,7 +2814,8 @@ public class SubsamplingScaleImageView extends View {
      * </p>
      * @param executor an {@link Executor} for image loading.
      */
-    public void setExecutor(Executor executor) {
+    public void setExecutor(@NonNull Executor executor) {
+        //noinspection ConstantConditions
         if (executor == null) {
             throw new NullPointerException("Executor must not be null");
         }
@@ -2869,6 +2894,7 @@ public class SubsamplingScaleImageView extends View {
      * @param sCenter Target center point
      * @return {@link AnimationBuilder} instance. Call {@link SubsamplingScaleImageView.AnimationBuilder#start()} to start the anim.
      */
+    @Nullable
     public AnimationBuilder animateCenter(PointF sCenter) {
         if (!isReady()) {
             return null;
@@ -2882,6 +2908,7 @@ public class SubsamplingScaleImageView extends View {
      * @param scale Target scale.
      * @return {@link AnimationBuilder} instance. Call {@link SubsamplingScaleImageView.AnimationBuilder#start()} to start the anim.
      */
+    @Nullable
     public AnimationBuilder animateScale(float scale) {
         if (!isReady()) {
             return null;
@@ -2896,6 +2923,7 @@ public class SubsamplingScaleImageView extends View {
      * @param sCenter Target source center.
      * @return {@link AnimationBuilder} instance. Call {@link SubsamplingScaleImageView.AnimationBuilder#start()} to start the anim.
      */
+    @Nullable
     public AnimationBuilder animateScaleAndCenter(float scale, PointF sCenter) {
         if (!isReady()) {
             return null;
@@ -2948,6 +2976,7 @@ public class SubsamplingScaleImageView extends View {
          * @param duration duration in milliseconds.
          * @return this builder for method chaining.
          */
+        @NonNull
         public AnimationBuilder withDuration(long duration) {
             this.duration = duration;
             return this;
@@ -2958,6 +2987,7 @@ public class SubsamplingScaleImageView extends View {
          * @param interruptible interruptible flag.
          * @return this builder for method chaining.
          */
+        @NonNull
         public AnimationBuilder withInterruptible(boolean interruptible) {
             this.interruptible = interruptible;
             return this;
@@ -2968,6 +2998,7 @@ public class SubsamplingScaleImageView extends View {
          * @param easing easing style.
          * @return this builder for method chaining.
          */
+        @NonNull
         public AnimationBuilder withEasing(int easing) {
             if (!VALID_EASING_STYLES.contains(easing)) {
                 throw new IllegalArgumentException("Unknown easing type: " + easing);
@@ -2981,6 +3012,7 @@ public class SubsamplingScaleImageView extends View {
          * @param listener The listener.
          * @return this builder for method chaining.
          */
+        @NonNull
         public AnimationBuilder withOnAnimationEventListener(OnAnimationEventListener listener) {
             this.listener = listener;
             return this;
@@ -2992,6 +3024,7 @@ public class SubsamplingScaleImageView extends View {
          * point and is stopped when the limit for each axis is reached. The latter behaviour is used for flings but
          * nothing else.
          */
+        @NonNull
         private AnimationBuilder withPanLimited(boolean panLimited) {
             this.panLimited = panLimited;
             return this;
@@ -3000,6 +3033,7 @@ public class SubsamplingScaleImageView extends View {
         /**
          * Only for internal use. Indicates what caused the animation.
          */
+        @NonNull
         private AnimationBuilder withOrigin(int origin) {
             this.origin = origin;
             return this;

--- a/library/src/main/java/com/davemorrissey/labs/subscaleview/decoder/CompatDecoderFactory.java
+++ b/library/src/main/java/com/davemorrissey/labs/subscaleview/decoder/CompatDecoderFactory.java
@@ -35,6 +35,7 @@ public class CompatDecoderFactory<T> implements DecoderFactory<T> {
     }
 
     @Override
+    @NonNull
     public T make() throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
         if (bitmapConfig == null) {
             return clazz.newInstance();

--- a/library/src/main/java/com/davemorrissey/labs/subscaleview/decoder/DecoderFactory.java
+++ b/library/src/main/java/com/davemorrissey/labs/subscaleview/decoder/DecoderFactory.java
@@ -1,5 +1,7 @@
 package com.davemorrissey.labs.subscaleview.decoder;
 
+import android.support.annotation.NonNull;
+
 import java.lang.reflect.InvocationTargetException;
 
 /**
@@ -16,6 +18,6 @@ public interface DecoderFactory<T> {
      * @throws NoSuchMethodException if the factory class cannot be instantiated.
      * @throws InvocationTargetException if the factory class cannot be instantiated.
      */
-    T make() throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException;
+    @NonNull T make() throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException;
 
 }

--- a/library/src/main/java/com/davemorrissey/labs/subscaleview/decoder/ImageDecoder.java
+++ b/library/src/main/java/com/davemorrissey/labs/subscaleview/decoder/ImageDecoder.java
@@ -3,6 +3,7 @@ package com.davemorrissey.labs.subscaleview.decoder;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.support.annotation.NonNull;
 
 /**
  * Interface for image decoding classes, allowing the default {@link android.graphics.BitmapFactory}
@@ -24,6 +25,6 @@ public interface ImageDecoder {
      * @return the decoded bitmap
      * @throws Exception if decoding fails.
      */
-    Bitmap decode(Context context, Uri uri) throws Exception;
+    @NonNull Bitmap decode(Context context, @NonNull Uri uri) throws Exception;
 
 }

--- a/library/src/main/java/com/davemorrissey/labs/subscaleview/decoder/ImageRegionDecoder.java
+++ b/library/src/main/java/com/davemorrissey/labs/subscaleview/decoder/ImageRegionDecoder.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.net.Uri;
+import android.support.annotation.NonNull;
 
 /**
  * Interface for image decoding classes, allowing the default {@link android.graphics.BitmapRegionDecoder}
@@ -26,7 +27,7 @@ public interface ImageRegionDecoder {
      * @return Dimensions of the image.
      * @throws Exception if initialisation fails.
      */
-    Point init(Context context, Uri uri) throws Exception;
+    @NonNull Point init(Context context, @NonNull Uri uri) throws Exception;
 
     /**
      * <p>
@@ -44,7 +45,7 @@ public interface ImageRegionDecoder {
      * @param sampleSize Sample size.
      * @return The decoded region. It is safe to return null if decoding fails.
      */
-    Bitmap decodeRegion(Rect sRect, int sampleSize);
+    @NonNull Bitmap decodeRegion(@NonNull Rect sRect, int sampleSize);
 
     /**
      * Status check. Should return false before initialisation and after recycle.

--- a/library/src/main/java/com/davemorrissey/labs/subscaleview/decoder/SkiaImageDecoder.java
+++ b/library/src/main/java/com/davemorrissey/labs/subscaleview/decoder/SkiaImageDecoder.java
@@ -8,6 +8,8 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.support.annotation.Keep;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView;
@@ -36,7 +38,7 @@ public class SkiaImageDecoder implements ImageDecoder {
     }
 
     @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
-    public SkiaImageDecoder(Bitmap.Config bitmapConfig) {
+    public SkiaImageDecoder(@Nullable Bitmap.Config bitmapConfig) {
         Bitmap.Config globalBitmapConfig = SubsamplingScaleImageView.getPreferredBitmapConfig();
         if (bitmapConfig != null) {
             this.bitmapConfig = bitmapConfig;
@@ -48,7 +50,8 @@ public class SkiaImageDecoder implements ImageDecoder {
     }
 
     @Override
-    public Bitmap decode(Context context, Uri uri) throws Exception {
+    @NonNull
+    public Bitmap decode(Context context, @NonNull Uri uri) throws Exception {
         String uriString = uri.toString();
         BitmapFactory.Options options = new BitmapFactory.Options();
         Bitmap bitmap;

--- a/library/src/main/java/com/davemorrissey/labs/subscaleview/decoder/SkiaImageRegionDecoder.java
+++ b/library/src/main/java/com/davemorrissey/labs/subscaleview/decoder/SkiaImageRegionDecoder.java
@@ -9,6 +9,8 @@ import android.graphics.*;
 import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.Keep;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView;
@@ -48,7 +50,7 @@ public class SkiaImageRegionDecoder implements ImageRegionDecoder {
     }
 
     @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
-    public SkiaImageRegionDecoder(Bitmap.Config bitmapConfig) {
+    public SkiaImageRegionDecoder(@Nullable Bitmap.Config bitmapConfig) {
         Bitmap.Config globalBitmapConfig = SubsamplingScaleImageView.getPreferredBitmapConfig();
         if (bitmapConfig != null) {
             this.bitmapConfig = bitmapConfig;
@@ -60,7 +62,8 @@ public class SkiaImageRegionDecoder implements ImageRegionDecoder {
     }
 
     @Override
-    public Point init(Context context, Uri uri) throws Exception {
+    @NonNull
+    public Point init(Context context, @NonNull Uri uri) throws Exception {
         String uriString = uri.toString();
         if (uriString.startsWith(RESOURCE_PREFIX)) {
             Resources res;
@@ -107,7 +110,8 @@ public class SkiaImageRegionDecoder implements ImageRegionDecoder {
     }
 
     @Override
-    public Bitmap decodeRegion(Rect sRect, int sampleSize) {
+    @NonNull
+    public Bitmap decodeRegion(@NonNull Rect sRect, int sampleSize) {
         getDecodeLock().lock();
         try {
             if (decoder != null && !decoder.isRecycled()) {

--- a/library/src/main/java/com/davemorrissey/labs/subscaleview/decoder/SkiaPooledImageRegionDecoder.java
+++ b/library/src/main/java/com/davemorrissey/labs/subscaleview/decoder/SkiaPooledImageRegionDecoder.java
@@ -15,6 +15,8 @@ import android.graphics.Rect;
 import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.Keep;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -82,7 +84,7 @@ public class SkiaPooledImageRegionDecoder implements ImageRegionDecoder {
     }
 
     @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
-    public SkiaPooledImageRegionDecoder(Bitmap.Config bitmapConfig) {
+    public SkiaPooledImageRegionDecoder(@Nullable Bitmap.Config bitmapConfig) {
         Bitmap.Config globalBitmapConfig = SubsamplingScaleImageView.getPreferredBitmapConfig();
         if (bitmapConfig != null) {
             this.bitmapConfig = bitmapConfig;
@@ -109,7 +111,8 @@ public class SkiaPooledImageRegionDecoder implements ImageRegionDecoder {
      * additional three decoders. The thread will abort if {@link #recycle()} is called.
      */
     @Override
-    public Point init(final Context context, final Uri uri) throws Exception {
+    @NonNull
+    public Point init(final Context context, @NonNull final Uri uri) throws Exception {
         this.context = context;
         this.uri = uri;
         initialiseDecoder();
@@ -245,7 +248,8 @@ public class SkiaPooledImageRegionDecoder implements ImageRegionDecoder {
      * method until after {@link #init(Context, Uri)}, so there will be no blocking on an empty pool.
      */
     @Override
-    public Bitmap decodeRegion(Rect sRect, int sampleSize) {
+    @NonNull
+    public Bitmap decodeRegion(@NonNull Rect sRect, int sampleSize) {
         debug("Decode region " + sRect + " on thread " + Thread.currentThread().getName());
         if (sRect.width() < imageDimensions.x || sRect.height() < imageDimensions.y) {
             lazyInit();


### PR DESCRIPTION
This library already has a strong notion of when parameters should or should not be `null`. This formalises this contract in a way that Kotlin recognises. 

- I have suppressed warnings now generated by adding the annotations. In all cases, I have checked the code flow to ensure that the warning suppression is correct.

Note: `ImageDecoder.decode()` The context is not marked as `@NotNull` because files do not require a context to be set. All other URI type would result in a NPE 

Formatting follows exist code and Google java style guide.