### PR TITLE
Additional sanity check when dealing with preview Bitmaps

### DIFF
--- a/library/src/main/java/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
+++ b/library/src/main/java/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
@@ -1080,7 +1080,7 @@ public class SubsamplingScaleImageView extends View {
                 }
             }
 
-        } else if (bitmap != null) {
+        } else if (bitmap != null && !bitmap.isRecycled()) {
 
             float xScale = scale, yScale = scale;
             if (bitmapIsPreview) {


### PR DESCRIPTION
If a preview bitmap was passed to SubsamplingScaleImageView and this bitmap was subsequently recycled, SubsamplingScaleImageView will still attempt to use this bitmap.

This change (in addition to the existing null check) checks if the bitmap is not recycled before attempting to draw it.