### PR TITLE
Change method name 'resource' to 'createImage'

### DIFF
--- a/library/src/main/java/com/davemorrissey/labs/subscaleview/ImageSource.java
+++ b/library/src/main/java/com/davemorrissey/labs/subscaleview/ImageSource.java
@@ -73,7 +73,7 @@ public final class ImageSource {
      * @return an {@link ImageSource} instance.
      */
     @NonNull
-    public static ImageSource resource(int resId) {
+    public static com.davemorrissey.labs.subscaleview.ImageSource createImage(int resId) {
         return new ImageSource(resId);
     }
 


### PR DESCRIPTION
This class is used to represent ImageSource.  This method named 'resource' is to ceate an image instance from a resource. Thus, the method name 'createImage' is more intuitive than 'resource'.