### PR TITLE
Fix native crash in BitmapRegionDecoder.

### DIFF
--- a/library/src/main/java/com/davemorrissey/labs/subscaleview/decoder/SkiaImageRegionDecoder.java
+++ b/library/src/main/java/com/davemorrissey/labs/subscaleview/decoder/SkiaImageRegionDecoder.java
@@ -99,6 +99,9 @@ public class SkiaImageRegionDecoder implements ImageRegionDecoder {
             try {
                 ContentResolver contentResolver = context.getContentResolver();
                 inputStream = contentResolver.openInputStream(uri);
+                if (inputStream == null) {
+                    throw new Exception("Content resolver returned null stream. Unable to initialise with uri.");
+                }
                 decoder = BitmapRegionDecoder.newInstance(inputStream, false);
             } finally {
                 if (inputStream != null) {


### PR DESCRIPTION

Fixes #489

Makes SkiaImageRegionDecoder throw an Exception from Java when it receives a null InputStream from the contentResolver.

A null InputStream passed into the BitmapRegionDecoder causes it to crash in android's native code which brings down the entire app. Throwing an Exception in java land is the safer option.