### PR TITLE
Fixes to cancel long click

### DIFF
--- a/library/src/main/java/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
+++ b/library/src/main/java/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
@@ -292,7 +292,7 @@ public class SubsamplingScaleImageView extends View {
         setGestureDetector(context);
         this.handler = new Handler(new Handler.Callback() {
             public boolean handleMessage(Message message) {
-                if (message.what == MESSAGE_LONG_CLICK && onLongClickListener != null) {
+                if (message.what == MESSAGE_LONG_CLICK && onLongClickListener != null && isLongClickable()) {
                     maxTouchCount = 0;
                     SubsamplingScaleImageView.super.setOnLongClickListener(onLongClickListener);
                     performLongClick();
@@ -2856,6 +2856,9 @@ public class SubsamplingScaleImageView extends View {
      */
     @Override
     public void setOnLongClickListener(OnLongClickListener onLongClickListener) {
+        if (!isLongClickable()) {
+            setLongClickable(true);
+        }
         this.onLongClickListener = onLongClickListener;
     }
 

--- a/library/src/main/java/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
+++ b/library/src/main/java/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
@@ -922,6 +922,13 @@ public class SubsamplingScaleImageView extends View {
                     maxTouchCount = 0;
                 }
                 return true;
+            case MotionEvent.ACTION_CANCEL:
+                handler.removeMessages(MESSAGE_LONG_CLICK);
+                isQuickScaling = false;
+                isZooming = false;
+                isPanning = false;
+                maxTouchCount = 0;
+                return true;
         }
         return false;
     }


### PR DESCRIPTION
First, respect `longClickable` attribute when set to false, by skipping the long click action. (Fixes #552)

Also cancel the long-click and other gestures when receiving `ACTION_CANCEL`, such as from Android 10 gesture navigation.